### PR TITLE
made hubconnection as singleton and added promise property to Hub

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -1,11 +1,15 @@
 angular.module('SignalR', [])
 .constant('$', $)
 .factory('Hub', ['$', function ($) {
+	//This will allow same connection to be used for all Hubs
+	//It also keeps connection as singleton.
+	var globalConnection = $.hubConnection();
 	return function (hubName, listeners, methods) {
 		var Hub = this;
-		Hub.connection = $.hubConnection();
+		Hub.connection = globalConnection;
 		Hub.proxy = Hub.connection.createHubProxy(hubName);
-		Hub.connection.start();
+		//Adding additional property of promise allows to access it in rest of the application.
+		Hub.promise = Hub.connection.start();		
 		Hub.on = function (event, fn) {
 			Hub.proxy.on(event, fn);
 		};


### PR DESCRIPTION
This will allow single Hub connection to be used for multiple hubs. Adding additional property to Hub for Promise returned by connection.start() will allow it to use safe invocation of method on hubs. This will guarantee that a connection is already done.
