### PR TITLE
Moved the start method of SignalR as the very last task.

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -8,8 +8,6 @@ angular.module('SignalR', [])
 		var Hub = this;
 		Hub.connection = globalConnection;
 		Hub.proxy = Hub.connection.createHubProxy(hubName);
-		//Adding additional property of promise allows to access it in rest of the application.
-		Hub.promise = Hub.connection.start();		
 		Hub.on = function (event, fn) {
 			Hub.proxy.on(event, fn);
 		};
@@ -31,6 +29,8 @@ angular.module('SignalR', [])
 				};
 			});
 		}
+		//Adding additional property of promise allows to access it in rest of the application.
+		Hub.promise = Hub.connection.start();		
 		return Hub;
 	};
 }]);


### PR DESCRIPTION
In the latest version of SignalR this would cause the connection to be started before the subscriber methods are added resulting in the error "No hubs have been subscribed to.  The client will not receive data from hubs.  To fix, declare at least one client side function prior to connection start for each hub you wish to subscribe to."
