### PR TITLE
Return the promise when calling server methods.

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -12,7 +12,7 @@ angular.module('SignalR', [])
 			Hub.proxy.on(event, fn);
 		};
 		Hub.invoke = function (method, args) {
-			Hub.proxy.invoke.apply(Hub.proxy, arguments)
+			return Hub.proxy.invoke.apply(Hub.proxy, arguments)
 		};
 
 		if (listeners) {
@@ -25,7 +25,7 @@ angular.module('SignalR', [])
 				Hub[method] = function () {
 					var args = $.makeArray(arguments);
 					args.unshift(method);
-					Hub.invoke.apply(Hub, args);
+					return Hub.invoke.apply(Hub, args);
 				};
 			});
 		}


### PR DESCRIPTION
SignalR returns a promise when invoking server methods. This can be useful when the client needs to do work on success or failure when calling the server method.
