### PR TITLE
Use non-minified version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
 		"type": "git",
 		"url": "git@github.com:JustMaier/angular-signalr-hub.git"
 	},
-	"main": "signalr-hub.min.js",
+	"main": "signalr-hub.js",
 	"dependencies": {
 		"angular": "*",
 		"jquery": "*",


### PR DESCRIPTION
Bower spec is that scripts should not be minified. Build tools handle
minification. https://github.com/bower/bower.json-spec#main
