### PR TITLE
added "logging" config option to activate signalR debug logging

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -11,6 +11,8 @@ angular.module('SignalR', [])
 		} else {
 			globalConnection = $.hubConnection();
 		}
+		
+		globalConnection.logging = (options && options.logging ? true : false);
 	};
 
 	return function (hubName, options) {


### PR DESCRIPTION
Allows activating the signalR client logging to the console by passing a new "logging" setting in the options object when creating a new Hub.
Didn't change the minified script file.
