### PR TITLE
Handle connection to multiple hosts when shared

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -3,7 +3,7 @@ angular.module('SignalR', [])
 .factory('Hub', ['$', function ($) {
 	//This will allow same connection to be used for all Hubs
 	//It also keeps connection as singleton.
-	var globalConnection = null;
+	var globalConnections = [];
 
 	function initNewConnection(options) {
 		var connection = null;
@@ -20,7 +20,9 @@ angular.module('SignalR', [])
 	function getConnection(options) {
 		var useSharedConnection = !(options && options.useSharedConnection === false);
 		if (useSharedConnection) {
-			return globalConnection === null ? globalConnection = initNewConnection(options) : globalConnection;
+			return typeof globalConnections[options.rootPath] === 'undefined' ?
+			globalConnections[options.rootPath] = initNewConnection(options) :
+			globalConnections[options.rootPath];
 		}
 		else {
 			return initNewConnection(options);


### PR DESCRIPTION
Connections should be host dependent to be able to connect to different SignalR servers at the same time.
