### PR TITLE
Added an option for Connection.disconnected event

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A handy wrapper for SignalR Hubs. Just specify the hub name, listening functions
 
 ```
 angular.module('app',['SignalR'])
-.factory('Employees',['$rootScope','Hub', function($rootScope, Hub){
+.factory('Employees',['$rootScope','Hub', '$timeout', function($rootScope, Hub, $timeout){
 
 	//declaring the hub connection
 	var hub = new Hub('employee', {
@@ -62,6 +62,22 @@ angular.module('app',['SignalR'])
 		//specify a non default root
 		//rootPath: '/api
 		
+		,
+            	hubDisconnected: function () {                
+                	if (hub.connection.lastError) {
+                    		hub.connection.start()
+                    		.done(function () {
+                        		if (hub.connection.state == 0)
+                            			$timeout(function () { //your code here }, 2000);
+                        		else
+                            			//your code here
+                    			})
+                    		.fail(function (reason) {
+                        		console.log(reason);
+                		}
+                		);
+                	}
+            	}
 	});
 
 	var edit = function (employee) {

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ angular.module('app',['SignalR'])
                     		.done(function () {
                         		if (hub.connection.state == 0)
                             			$timeout(function () { //your code here }, 2000);
-                        		else
+                        		else{
                             			//your code here
                     			})
                     		.fail(function (reason) {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ angular.module('app',['SignalR'])
 		//specify a non default root
 		//rootPath: '/api
 		
-		,
             	hubDisconnected: function () {                
                 	if (hub.connection.lastError) {
                     		hub.connection.start()

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ angular.module('app',['SignalR'])
 * `logging` enable/disable logging
 * `useSharedConnection` use a shared global connection or create a new one just for this hub, defaults to `true`
 * `transport` sets transport method (e.g ```'longPolling'``` or ```['webSockets', 'longPolling']```)
+* `hubDisconnected` function() to handle hub connection disconnected event
 
 ##Demo
 

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -68,6 +68,12 @@ angular.module('SignalR', [])
 		if (options && options.errorHandler) {
 			Hub.connection.error(options.errorHandler);
 		}
+		//Allow for the user of the hub to easily implement actions upon disconnected.
+		//e.g. : Laptop/PC sleep and reopen, one might want to automatically reconnect 
+		//by using the disconnected event on the connection as the starting point.
+		if (options && options.hubDisconnected) {
+		    Hub.connection.disconnected(options.hubDisconnected);
+		}
 
 		//Adding additional property of promise allows to access it in rest of the application.
 		Hub.promise = Hub.connect();


### PR DESCRIPTION
I had a requirement to automatically reconnect when a disconnected event occurred on the connection that was not triggered manually.
So I added a 'hubDisconnected' option, which can be used to provide a function to execute some code upon the disconnected event.