### PR TITLE
Update signalr-hub.js

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -58,7 +58,13 @@ angular.module('SignalR', [])
 				Hub[method] = function () {
 					var args = $.makeArray(arguments);
 					args.unshift(method);
-					return Hub.invoke.apply(Hub, args);
+					if (Hub.connection.state !== 1) {
+					    Hub.connection.start().then(function () {
+				                return Hub.invoke.apply(Hub, args);
+				            });
+				        } else {
+				            return Hub.invoke.apply(Hub, args);
+				        }
 				};
 			});
 		}


### PR DESCRIPTION
If the connection has died, due to inactivity, this will restart the hub connection on any try calling a method on the hub