### PR TITLE
Add a monitor for all connection state changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,6 @@ angular.module('app',['SignalR'])
 		//specify a non default root
 		//rootPath: '/api
 		
-		hubDisconnected: function () {                
-			if (hub.connection.lastError) {
-                hub.connection.start()
-					.done(function () {
-						if (hub.connection.state === 0) {
-						    $timeout(function () { 
-						        //your code here 
-						    }, 2000);
-						} else {
-						    //your code here
-						}
-                    })
-					.fail(function (reason) {
-						console.log(reason);
-				    });
-			}
-		}
 	});
 
 	var edit = function (employee) {

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ angular.module('app',['SignalR'])
 * `logging` enable/disable logging
 * `useSharedConnection` use a shared global connection or create a new one just for this hub, defaults to `true`
 * `transport` sets transport method (e.g ```'longPolling'``` or ```['webSockets', 'longPolling']```)
-* `hubDisconnected` function() to handle hub connection disconnected event
+* **DEPRECATED** `hubDisconnected` function() to handle hub connection disconnected event
 
 ##Demo
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ angular.module('app',['SignalR'])
 		//specify a non default root
 		//rootPath: '/api
 		
+        stateChanged: function(state){
+            switch (state.newState) {
+                case $.signalR.connectionState.connecting:
+                    //your code here
+                    break;
+                case $.signalR.connectionState.connected:
+                    //your code here
+                    break;
+                case $.signalR.connectionState.reconnecting:
+                    //your code here
+                    break;
+                case $.signalR.connectionState.disconnected:
+                    //your code here
+                    break;
+            }
+        }
 	});
 
 	var edit = function (employee) {
@@ -90,6 +106,7 @@ angular.module('app',['SignalR'])
 * `useSharedConnection` use a shared global connection or create a new one just for this hub, defaults to `true`
 * `transport` sets transport method (e.g ```'longPolling'``` or ```['webSockets', 'longPolling']```)
 * **DEPRECATED** `hubDisconnected` function() to handle hub connection disconnected event
+* `stateChanged` function() to handle hub connection state changed event
 
 ##Demo
 

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -68,11 +68,32 @@ angular.module('SignalR', [])
 		if (options && options.errorHandler) {
 			Hub.connection.error(options.errorHandler);
 		}
-		//Allow for the user of the hub to easily implement actions upon disconnected.
-		//e.g. : Laptop/PC sleep and reopen, one might want to automatically reconnect 
-		//by using the disconnected event on the connection as the starting point.
-		if (options && options.hubDisconnected) {
-		    Hub.connection.disconnected(options.hubDisconnected);
+
+		if (
+			options &&
+			(
+				options.hubDisconnected ||
+				options.hubConnected ||
+				options.hubReconnecting ||
+				options.hubDisconnected
+			)
+		) {
+		    Hub.connection.stateChanged(function (state) {
+		        switch (state.newState) {
+		            case $.signalR.connectionState.connecting:
+		                options.hubConnecting && options.hubConnecting.call(this);
+		                break;
+		            case $.signalR.connectionState.connected:
+		                options.hubConnected && options.hubConnected.call(this);
+		                break;
+		            case $.signalR.connectionState.reconnecting:
+		                options.hubReconnecting && options.hubReconnecting.call(this);
+		                break;
+		            case $.signalR.connectionState.disconnected:
+		                options.hubDisconnected && options.hubDisconnected.call(this);
+		                break;
+		        }
+		    });
 		}
 
 		//Adding additional property of promise allows to access it in rest of the application.

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -68,6 +68,7 @@ angular.module('SignalR', [])
 		if (options && options.errorHandler) {
 			Hub.connection.error(options.errorHandler);
 		}
+        //DEPRECATED
 		//Allow for the user of the hub to easily implement actions upon disconnected.
 		//e.g. : Laptop/PC sleep and reopen, one might want to automatically reconnect 
 		//by using the disconnected event on the connection as the starting point.

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -74,6 +74,9 @@ angular.module('SignalR', [])
 		if (options && options.hubDisconnected) {
 		    Hub.connection.disconnected(options.hubDisconnected);
 		}
+		if (options && options.stateChanged) {
+		    Hub.connection.stateChanged(options.stateChanged);
+		}
 
 		//Adding additional property of promise allows to access it in rest of the application.
 		Hub.promise = Hub.connect();

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -68,32 +68,11 @@ angular.module('SignalR', [])
 		if (options && options.errorHandler) {
 			Hub.connection.error(options.errorHandler);
 		}
-
-		if (
-			options &&
-			(
-				options.hubDisconnected ||
-				options.hubConnected ||
-				options.hubReconnecting ||
-				options.hubDisconnected
-			)
-		) {
-		    Hub.connection.stateChanged(function (state) {
-		        switch (state.newState) {
-		            case $.signalR.connectionState.connecting:
-		                options.hubConnecting && options.hubConnecting.call(this);
-		                break;
-		            case $.signalR.connectionState.connected:
-		                options.hubConnected && options.hubConnected.call(this);
-		                break;
-		            case $.signalR.connectionState.reconnecting:
-		                options.hubReconnecting && options.hubReconnecting.call(this);
-		                break;
-		            case $.signalR.connectionState.disconnected:
-		                options.hubDisconnected && options.hubDisconnected.call(this);
-		                break;
-		        }
-		    });
+		//Allow for the user of the hub to easily implement actions upon disconnected.
+		//e.g. : Laptop/PC sleep and reopen, one might want to automatically reconnect 
+		//by using the disconnected event on the connection as the starting point.
+		if (options && options.hubDisconnected) {
+		    Hub.connection.disconnected(options.hubDisconnected);
 		}
 
 		//Adding additional property of promise allows to access it in rest of the application.


### PR DESCRIPTION
This monitors all state changes and not only the disconnection.

Not sure if we should get that many events or just implement a global stateChanged event (would be a breaking change though) ?