### PR TITLE
Using $apply as mentioned in #42

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -1,6 +1,6 @@
 angular.module('SignalR', [])
 .constant('$', window.jQuery)
-.factory('Hub', ['$','$scope','$q', function ($, $scope, $q) {
+.factory('Hub', ['$','$rootScope','$q', function ($, $rootScope, $q) {
 	//This will allow same connection to be used for all Hubs
 	//It also keeps connection as singleton.
 	var globalConnections = [];
@@ -37,12 +37,13 @@ angular.module('SignalR', [])
 
 		Hub.on = function (event, fn) {
 			Hub.proxy.on(event, function(){
-				$scope.$apply(fn);
+				$rootScope.$apply(fn);
 			});
 		};
 		Hub.invoke = function (method, args) {
+			var args = arguments;
 			return $q(function(resolve,reject){
-				Hub.proxy.invoke.apply(Hub.proxy, arguments).done(resolve).fail(reject);
+				Hub.proxy.invoke.apply(Hub.proxy, args).done(resolve).fail(reject);
 			});
 		};
 		Hub.disconnect = function () {

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -1,6 +1,6 @@
 angular.module('SignalR', [])
 .constant('$', window.jQuery)
-.factory('Hub', ['$', function ($) {
+.factory('Hub', ['$','$scope','$q', function ($, $scope, $q) {
 	//This will allow same connection to be used for all Hubs
 	//It also keeps connection as singleton.
 	var globalConnections = [];
@@ -36,10 +36,14 @@ angular.module('SignalR', [])
 		Hub.proxy = Hub.connection.createHubProxy(hubName);
 
 		Hub.on = function (event, fn) {
-			Hub.proxy.on(event, fn);
+			Hub.proxy.on(event, function(){
+				$scope.$apply(fn);
+			});
 		};
 		Hub.invoke = function (method, args) {
-			return Hub.proxy.invoke.apply(Hub.proxy, arguments)
+			return $q(function(resolve,reject){
+				Hub.proxy.invoke.apply(Hub.proxy, arguments).done(resolve).fail(reject);
+			});
 		};
 		Hub.disconnect = function () {
 			Hub.connection.stop();


### PR DESCRIPTION
This makes the hub service use the apply function, making it so that you
do not have to call $apply() in every callback.

At the same time, invoke has been updated to return a angluar promise,
for the same reason