### PR TITLE
Allow a 'class' instance in the listener instead of inline definitions

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -49,9 +49,12 @@ angular.module('SignalR', [])
 		};
 
 		if (options && options.listeners) {
-			angular.forEach(options.listeners, function (fn, event) {
-				Hub.on(event, fn);
-			});
+			Object.getOwnPropertyNames(options.listeners)
+			.filter(function (propName) {
+		        	return typeof options.listeners[propName] === 'function';})
+		        .forEach(function (propName) {
+		        	Hub.on(propName, options.listeners[propName]);
+		    	});
 		}
 		if (options && options.methods) {
 			angular.forEach(options.methods, function (method) {


### PR DESCRIPTION
I'm using TypeScript and I wanted to implement the client as a class (and its interface) in a separatedly place where Hub definition is.
Setting up the listener property with 'new Client(args)' instead of defining the object inline, It didn't work. I think because angular.foreach skip prototypes properties. So, with this change i think it does it ok.
In Javascript you can benefit from the same idea.

For example:

```typescript

    export interface IMyClient {
        stuffCreated(stuffName: string, stuff: Stuff): void;
        stuffDeleted(stuffName: string, stuffId: number): void;
    }

    class MyClient implements IMyClient {

        public constructor(private toastr: Toastr) {}

        public stuffCreated(stuffName: string, stuff: Stuff): void {
            toastr.info('stuff '+stuffName + ' created');
        }
        public stuffDeleted(stuffName: string, stuffId: number): void {
            toastr.info('stuff '+stuffName + ' deleted');
        }
    }

       ngModule.factory('StuffService', (Hub, toastr: Toastr) => {
        var hub = new Hub('stuffHub', {
            listeners: new EntityChannelClient(toastr),
            methods: [],
            errorHandler: (error) => console.error(error),
        });
        return {};
    });
```