### PR TITLE
Add CommonJS support

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -87,3 +87,8 @@ angular.module('SignalR', [])
 		return Hub;
 	};
 }]);
+
+// Common.js package manager support (e.g. ComponentJS, WebPack)
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
+  module.exports = 'leonardo';
+}

--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -90,5 +90,5 @@ angular.module('SignalR', [])
 
 // Common.js package manager support (e.g. ComponentJS, WebPack)
 if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
-  module.exports = 'leonardo';
+  module.exports = 'SignalR';
 }


### PR DESCRIPTION
Can we add support for loading the module as a CommonJS module?

See example of Angular UI-Router:
https://github.com/angular-ui/ui-router/blob/master/release/angular-ui-router.js

This will allow doing:
```js
var SignalR = require('angular-signalr-hub');

angular.module('app', [
    SignalR
])
```

Instead of hard coding the module name.